### PR TITLE
WIP: Support for Android Keystore signing

### DIFF
--- a/src/main/java/com/authlete/cose/ECDSA.java
+++ b/src/main/java/com/authlete/cose/ECDSA.java
@@ -461,7 +461,7 @@ class ECDSA
         switch (algorithm)
         {
             case COSEAlgorithms.ES256:
-                return beforeJre9 ? "SHA256withPLAIN-ECDSA" : "SHA256withECDSAinP1363Format";
+                return "SHA256withECDSA"; // TODO: resolve this after testing
 
             case COSEAlgorithms.ES384:
                 return beforeJre9 ? "SHA384withPLAIN-ECDSA" : "SHA384withECDSAinP1363Format";

--- a/src/main/java/com/authlete/cose/ECDSA.java
+++ b/src/main/java/com/authlete/cose/ECDSA.java
@@ -356,7 +356,7 @@ class ECDSA
     static byte[] sign(Key key, int algorithm, byte[] data) throws COSEException
     {
         // Make sure that the key implements the ECPrivateKey interface.
-        ECPrivateKey priKey = castByPrivateKey(key, algorithm);
+        PrivateKey priKey = (PrivateKey)key;
 
         // Get a Signature instance that performs signing.
         Signature sig = getSignatureInstance(algorithm);
@@ -413,24 +413,6 @@ class ECDSA
         // Verify the signature.
         return verifySignature(sig, signature);
     }
-
-
-    /**
-     * Cast the key by ECPrivateKey.
-     */
-    private static ECPrivateKey castByPrivateKey(Key key, int algorithm) throws COSEException
-    {
-        // If the key does not implement the ECPrivateKey interface.
-        if (!(key instanceof ECPrivateKey))
-        {
-            throw new COSEException(String.format(
-                    "A key to sign data with the algorithm '%s' must implement the ECPrivateKey interface.",
-                    COSEAlgorithms.getNameByValue(algorithm)));
-        }
-
-        return (ECPrivateKey)key;
-    }
-
 
     /**
      * Cast the key by ECPublicKey.


### PR DESCRIPTION
This is not a complete PR, but I wanted to share it in order to show what is necessary to make the library support Android Keystore.

2 changes are necessary:

1. Remove (or avoid when dealing with Android Keystore key) `castByPrivateKey` because the `PrivateKey` object returned by Android Keystore cannot be cast to `ECPrivateKey`.
2. A change to `determineAlgorithmName` so that if it is on the Android platform it returns algorithms such as `"SHA256withECDSA"`, since neither option is supported when using Android Keystore.

wdyt?