### PR TITLE
[bugfix] IssuerSignedBuilder.prepareIssuerAuthPayload(IssuerNameSpaces)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,25 @@
 CHANGES
 =======
 
+- `IssuerSignedBuilder` class
+  * Fixed a bug in the `prepareIssuerAuthPayload(IssuerNameSpaces)` method.
+    The definitions of `IssuerAuth` and `MobileSecurityObjectBytes` in the
+    ISO/IEC 18013-5 specification give the impression that
+    `MobileSecurityObjectBytes` (which starts with a CBOR tag) is directly
+    used as the payload of `COSE_Sign1`. However, it is necessary to
+    further convert `MobileSecurityObjectBytes` into a byte string.
+
+- `SigStructure` class
+  * Changed the type of the fourth argument (`payload`) of the 4-argument
+    constructor from `CBORItem` to `CBORByteArray`.
+  * Changed the type of the third argument (`payload`) of the 3-argument
+    constructor from `CBORItem` to `CBORByteArray`.
+  * Changed the return type of the `getPayload()` method from `CBORItem` to
+   `CBORByteArray`.
+
+- `SigStructureBuilder` class
+  * Removed the `payload(CBORItem)` method.
+
 1.15 (2024-05-11)
 -----------------
 

--- a/src/main/java/com/authlete/cose/SigStructure.java
+++ b/src/main/java/com/authlete/cose/SigStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Authlete, Inc.
+ * Copyright (C) 2023-2024 Authlete, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package com.authlete.cose;
 
 
 import com.authlete.cbor.CBORByteArray;
-import com.authlete.cbor.CBORItem;
 import com.authlete.cbor.CBORItemList;
 import com.authlete.cbor.CBORString;
 
@@ -63,14 +62,6 @@ public class SigStructure extends CBORItemList
      * This constructor is for {@code COSE_Sign}.
      * </p>
      *
-     * <p>
-     * The type of the {@code payload} argument has been changed from
-     * {@link CBORByteArray} to {@link CBORItem} since version 1.5. This is
-     * because the <a href="https://www.iso.org/standard/69084.html">ISO/IEC
-     * 18013-5:2021</a> standard requires that the payload start with a tag
-     * instead of a byte string.
-     * </p>
-     *
      * @param bodyAttributes
      *         The protected header of the content. Must not be null.
      *
@@ -83,10 +74,11 @@ public class SigStructure extends CBORItemList
      * @param payload
      *         The payload.
      */
+    @SuppressWarnings("unchecked")
     public SigStructure(
             COSEProtectedHeader bodyAttributes,
             COSEProtectedHeader signerAttributes,
-            CBORByteArray externalData, CBORItem payload)
+            CBORByteArray externalData, CBORByteArray payload)
     {
         super(CONTEXT_SIGNATURE, bodyAttributes, signerAttributes, externalData, payload);
 
@@ -105,14 +97,6 @@ public class SigStructure extends CBORItemList
      * This constructor is for {@code COSE_Sign1}.
      * </p>
      *
-     * <p>
-     * The type of the {@code payload} argument has been changed from
-     * {@link CBORByteArray} to {@link CBORItem} since version 1.5. This is
-     * because the <a href="https://www.iso.org/standard/69084.html">ISO/IEC
-     * 18013-5:2021</a> standard requires that the payload start with a tag
-     * instead of a byte string.
-     * </p>
-     *
      * @param bodyAttributes
      *         The protected header of the content. Must not be null.
      *
@@ -122,9 +106,10 @@ public class SigStructure extends CBORItemList
      * @param payload
      *         The payload.
      */
+    @SuppressWarnings("unchecked")
     public SigStructure(
             COSEProtectedHeader bodyAttributes,
-            CBORByteArray externalData, CBORItem payload)
+            CBORByteArray externalData, CBORByteArray payload)
     {
         super(CONTEXT_SIGNATURE1, bodyAttributes, externalData, payload);
 
@@ -217,15 +202,15 @@ public class SigStructure extends CBORItemList
      * @return
      *         The payload.
      */
-    public CBORItem getPayload()
+    public CBORByteArray getPayload()
     {
         if (isSignature())
         {
-            return getItems().get(4);
+            return (CBORByteArray)getItems().get(4);
         }
         else
         {
-            return getItems().get(3);
+            return (CBORByteArray)getItems().get(3);
         }
     }
 

--- a/src/main/java/com/authlete/cose/SigStructureBuilder.java
+++ b/src/main/java/com/authlete/cose/SigStructureBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Authlete, Inc.
+ * Copyright (C) 2023-2024 Authlete, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ public class SigStructureBuilder
     private COSEProtectedHeader bodyAttributes;
     private COSEProtectedHeader signerAttributes;
     private CBORByteArray externalData;
-    private CBORItem payload;
+    private CBORByteArray payload;
 
 
     /**
@@ -210,25 +210,6 @@ public class SigStructureBuilder
 
 
     /**
-     * Set the payload to {@code Sig_structure.payload}.
-     *
-     * @param payload
-     *         The payload to be signed.
-     *
-     * @return
-     *         {@code this} object.
-     *
-     * @since 1.5
-     */
-    public SigStructureBuilder payload(CBORItem payload)
-    {
-        this.payload = payload;
-
-        return this;
-    }
-
-
-    /**
      * Set some fields of {@code Sig_structure} based on the given
      * {@link COSESign} object that represents {@code COSE_Sign}
      * which is defined in <a href=
@@ -271,7 +252,7 @@ public class SigStructureBuilder
 
         if (payload != null && !(payload instanceof CBORNull))
         {
-            payload(payload);
+            payload((CBORByteArray)payload);
         }
 
         return this;
@@ -349,7 +330,7 @@ public class SigStructureBuilder
 
         if (payload != null && !(payload instanceof CBORNull))
         {
-            payload(payload);
+            payload((CBORByteArray)payload);
         }
 
         return this;


### PR DESCRIPTION
The definitions of `IssuerAuth` and `MobileSecurityObjectBytes` in the ISO/IEC 18013-5 specification give the impression that `MobileSecurityObjectBytes` (which starts with a CBOR tag) is directly used as the payload of `COSE_Sign1`. However, it is necessary to further convert `MobileSecurityObjectBytes` into a byte string.