### PR TITLE
Parse encoded cbor data item

### DIFF
--- a/src/main/java/com/authlete/cbor/CBORByteArray.java
+++ b/src/main/java/com/authlete/cbor/CBORByteArray.java
@@ -18,6 +18,7 @@ package com.authlete.cbor;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -313,6 +314,24 @@ public class CBORByteArray extends CBORValue<byte[]>
         }
     }
 
+    @Override
+    protected Object parse(Number tagNumber) {
+        if (!isEncodedCborDataItem(tagNumber)) {
+            return getValue();
+        }
+        List<? extends CBORItem> items = prepareDecodedContent();
+        if (items != null) {
+            if (items.size() > 1) {
+            List<Object> list = new ArrayList<>();
+            items.stream().map(CBORItem::parse).forEachOrdered(list::add);
+            return list;
+            } else {
+               return items.get(0).parse();
+            }
+        } else {
+            return getValue();
+        }
+    }
 
     private String prettifyString(String comment)
     {

--- a/src/main/java/com/authlete/cbor/CBORItem.java
+++ b/src/main/java/com/authlete/cbor/CBORItem.java
@@ -79,6 +79,22 @@ public abstract class CBORItem
      */
     public abstract Object parse();
 
+    /**
+     * Convert this {@link CBORItem} instance into an instance of a common Java class. The default
+     * implementation of this method calls the {@code parse()} method.
+     *
+     * @param tagNumber
+     *         The tag number of the tag wrapping this CBOR item. If this CBOR
+     *         item is not wrapped, {@code null} is passed.
+     *
+     * @return
+     *         An instance of a common Java class that represents this CBOR data item.
+     */
+    protected Object parse(Number tagNumber)
+    {
+        return parse();
+    }
+
 
     /**
      * Write the CBOR representation of this instance into the output stream.

--- a/src/main/java/com/authlete/cbor/CBORTaggedItem.java
+++ b/src/main/java/com/authlete/cbor/CBORTaggedItem.java
@@ -132,6 +132,6 @@ public class CBORTaggedItem extends CBORItem
     @Override
     public Object parse()
     {
-        return tagContent.parse();
+        return tagContent.parse(tagNumber);
     }
 }

--- a/src/test/java/com/authlete/cbor/CBORParsingTest.java
+++ b/src/test/java/com/authlete/cbor/CBORParsingTest.java
@@ -196,6 +196,31 @@ public class CBORParsingTest
         assertArrayEquals(expected, (byte[])object);
     }
 
+    @Test
+    public void test_byte_array_cbor() throws IOException
+    {
+        // === byte[] ===
+        //
+        // CBOR data item representing tagged CBOR data
+        // encoded d818456449455446.
+        //
+        //   major = 24  ; byte string
+        //
+        byte[] input = {
+                (byte)0xd8, (byte)0x18, (byte)0x45, (byte)0x64,
+                (byte)0x49, (byte)0x45, (byte)0x54, (byte)0x46
+        };
+
+        // Expected result.
+        String expected ="IETF";
+
+        // Parse the CBOR data item.
+        Object object = new CBORParser(input).next();
+
+        // The object should be a String instance.
+        assertSame(String.class, object.getClass());
+        assertEquals(expected, (String)object);
+    }
 
     @Test
     public void test_string() throws IOException


### PR DESCRIPTION
Parsing of mdoc leads to bunch of byte arrays, which is difficult to handle without enclosing tagNumber information (and which is missing in parsed objects).
Change parsing so that we just parse encoded cbor when we find one.  