### PR TITLE
feat: configurable signer

### DIFF
--- a/src/main/java/com/authlete/mdoc/InternalSigStructureSigner.java
+++ b/src/main/java/com/authlete/mdoc/InternalSigStructureSigner.java
@@ -1,0 +1,28 @@
+package com.authlete.mdoc;
+
+import com.authlete.cose.COSEEC2Key;
+import com.authlete.cose.COSEException;
+import com.authlete.cose.COSESigner;
+import com.authlete.cose.SigStructure;
+import com.authlete.mdoc.interfaces.SigStructureSigner;
+
+import java.security.interfaces.ECPrivateKey;
+
+public class InternalSigStructureSigner implements SigStructureSigner {
+    private final COSEEC2Key issuerKey;
+
+    public InternalSigStructureSigner(COSEEC2Key issuerKey) {
+        this.issuerKey = issuerKey;
+    }
+
+    public byte[] sign(SigStructure sigStructure, int alg) throws COSEException {
+        // The private key for signing.
+        ECPrivateKey privateKey = issuerKey.toECPrivateKey();
+
+        // Create a signer with the private key.
+        COSESigner signer = new COSESigner(privateKey);
+
+        // Sign the Sig_structure (= generate a signature).
+        return signer.sign(sigStructure, alg);
+    }
+}

--- a/src/main/java/com/authlete/mdoc/interfaces/SigStructureSigner.java
+++ b/src/main/java/com/authlete/mdoc/interfaces/SigStructureSigner.java
@@ -1,0 +1,9 @@
+package com.authlete.mdoc.interfaces;
+
+import com.authlete.cose.COSEEC2Key;
+import com.authlete.cose.COSEException;
+import com.authlete.cose.SigStructure;
+
+public interface SigStructureSigner {
+    byte[] sign(SigStructure sigStructure, int alg) throws COSEException;
+}


### PR DESCRIPTION
Adds the possibility for library consumers to sign `IssuerSigned` structures using a signer of their choice.

This is useful for scenarios when the private key of the signer cannot be loaded in-memory (eg: HSM-bound keys).

The default behavior still uses the in-memory key signing.